### PR TITLE
Arrow keys not working for dropdowns (one commit this time!)

### DIFF
--- a/src/sscr.js
+++ b/src/sscr.js
@@ -322,7 +322,8 @@ function keydown(event) {
     
     // do nothing if user is editing text
     // or using a modifier key (except shift)
-    if ( /input|textarea|embed/i.test(target.nodeName) ||
+    // or in a dropdown
+    if ( /input|textarea|embed|select/i.test(target.nodeName) ||
          target.isContentEditable || 
          event.defaultPrevented   ||
          modifier ) {


### PR DESCRIPTION
I redid it as a single commit.

From previous pull request: Normally, when a dropdown had focus, the up and down keys let you change your selection without opening the dropdown. SmoothScroll broke this. I added dropdowns to the list of ignore-keys-when-focused in keydown(). The extra commits are due to me being new to git.
