### PR TITLE
Add an exclusion check for the onMouseWheel triggering bug fix.

### DIFF
--- a/src/sscr.js
+++ b/src/sscr.js
@@ -136,9 +136,9 @@ function init() {
      * the content does not trigger the onmousewheel event
      * on some pages. e.g.: html, body { height: 100% }
      */
-    else if (scrollHeight > windowHeight &&
+    else if (!isExcluded && (scrollHeight > windowHeight &&
             (body.offsetHeight <= windowHeight || 
-             html.offsetHeight <= windowHeight)) {
+             html.offsetHeight <= windowHeight))) {
 
         // DOMChange (throttle): fix height
         var pending = false;


### PR DESCRIPTION
Web pages that are on the excluded list shouldn't really have their styles changed unless required.
Some websites also require "html, body { Height : 100% }" in able for them to function correctly.
For example: Wallbase.cc's wallpaper pages.
