### PR TITLE
Fix for #81: My "fix" (it's not a good fix... it's option B in my bugreport)

### DIFF
--- a/src/sscr.js
+++ b/src/sscr.js
@@ -225,9 +225,9 @@ function scrollArray(elem, left, top, delay) {
     que.push({
         x: left, 
         y: top, 
+        now: 0,
         lastX: (left < 0) ? 0.99 : -0.99,
         lastY: (top  < 0) ? 0.99 : -0.99, 
-        start: +new Date
     });
         
     // don't act if there's a pending queue
@@ -246,7 +246,9 @@ function scrollArray(elem, left, top, delay) {
         for (var i = 0; i < que.length; i++) {
             
             var item = que[i];
-            var elapsed  = now - item.start;
+            
+            elapsed = item.now;
+            item.now += 16; 
             var finished = (elapsed >= options.animationTime);
             
             // scroll position: [0, 1]
@@ -580,6 +582,9 @@ function pulse(x) {
     return pulse_(x);
 }
 
+// new standard wheel event from Chrome 31+
+var wheelEvent = "onwheel" in document.createElement("div") ? "wheel" : "mousewheel"; 
+
 addEvent("mousedown", mousedown);
-addEvent("mousewheel", wheel);
+addEvent(wheelEvent, wheel);
 addEvent("load", init);


### PR DESCRIPTION
#81

The reason it's not an ideal fix is that I threw away the time-sample based progression. Now if something blocks and comes back (e.g. debugging the script), the animation will annoyingly step through all the way, rather than realizing that "time's up". However, the Chrome bug with the bad low-precision time readings forced my hand. 

If you have a user with a 120Hz monitor and a 60Hz monitor connected to the came computer, the animations will complete exactly twice as fast on the faster monitor. This is perhaps not ideal, it should be equally fast, but one should just be twice as smooth. Again, no bulletproof way to normalize this, so I just didn't try (When I tried, it got ugly -- this is the wrong place to try making sophisticated heuristics). 
