### PR TITLE
Add a "natural scrolling" option to reverse the scroll direction.

### DIFF
--- a/pages/options.html
+++ b/pages/options.html
@@ -252,6 +252,8 @@ label[title], .help  { cursor:help;  }
 
 <h2>Features</h2>
 
+<input type="checkbox" id="naturalScroll"><label for="naturalScroll" title="reverses scroll direction">Enable <b>natural scrolling</b></label><br><br>
+
 <input type="checkbox" id="keyboardSupport"><label for="keyboardSupport">Enable <b>keyboard support</b></label><br><br>
 
 <input type="checkbox" id="touchpadSupport"><label for="touchpadSupport">Enable <b>touchpad support</b></label><br><br>

--- a/pages/options.js
+++ b/pages/options.js
@@ -14,6 +14,7 @@ var optionsList = [
   'middleMouse',
   'accelerationMax',
   'accelerationDelta',
+  'naturalScroll',
   'pulseAlgorithm',
   'pulseScale',
   'keyboardSupport',
@@ -49,7 +50,7 @@ function hide(elem, newop) {
 }
 
 function isCheckbox(key) {
-  var re = /^(?:keyboardSupport|touchpadSupport|middleMouse|pulseAlgorithm|fixedBackground)$/;
+  var re = /^(?:keyboardSupport|touchpadSupport|middleMouse|pulseAlgorithm|fixedBackground|naturalScroll)$/;
   return re.test(key);
 }
 

--- a/src/sscr.js
+++ b/src/sscr.js
@@ -14,6 +14,7 @@ var defaultOptions = {
     frameRate        : 150, // [Hz]
     animationTime    : 400, // [px]
     stepSize         : 100, // [px]
+    naturalScroll    : false,
 
     // Pulse (less tweakable)
     // ratio of 'tail' to 'acceleration'
@@ -388,11 +389,15 @@ function wheel(event) {
     // scale by step size
     // delta is 120 most of the time
     // synaptics seems to send 1 sometimes
+    var stepSize = options.stepSize / 120;
+    if (options.naturalScroll) {
+        stepSize *= -1;
+    }
     if (Math.abs(deltaX) > 1.2) {
-        deltaX *= options.stepSize / 120;
+        deltaX *= stepSize;
     }
     if (Math.abs(deltaY) > 1.2) {
-        deltaY *= options.stepSize / 120;
+        deltaY *= stepSize;
     }
     
     scrollArray(overflowing, deltaX, deltaY);


### PR DESCRIPTION
This is more relevant as Chrome has switched to xinput2, which doesn't support system-wide natural scrolling for certain mouses (see https://bugs.chromium.org/p/chromium/issues/detail?id=582547).
