### PR TITLE
Fix scrolling after elements have been removed

### DIFF
--- a/src/sscr.js
+++ b/src/sscr.js
@@ -376,9 +376,10 @@ function keydown(event) {
     var modifier = event.ctrlKey || event.altKey || event.metaKey || 
                   (event.shiftKey && event.keyCode !== key.spacebar);
 
-    // our own tracked active element could've been removed from the DOM
-    if (!document.contains(activeElement)) {
-        let newActiveElement = document.activeElement;
+    // Our own tracked active element could've been deactive by being removed from the DOM
+    // or made invisible.
+    let newActiveElement = document.activeElement;
+    if (newActiveElement !== activeElement) {
         if (newActiveElement === document.body) {
             // Chrome resets it to the body when an element goes away,
             // but often the thing that's being scrolled is a child.


### PR DESCRIPTION
This extension has the same issue that chrome has with its own
scrolling when trying to scroll after clicking on an element that
gets removed from the DOM -- see
https://bugs.chromium.org/p/chromium/issues/detail?id=853052.

This needs some refactoring, but putting it up as-is for now.
