### PR TITLE
Handle cmd+up and cmd+down

### DIFF
--- a/src/sscr.js
+++ b/src/sscr.js
@@ -374,7 +374,8 @@ function wheel(event) {
 function keydown(event) {
 
     var target   = event.target;
-    var modifier = event.ctrlKey || event.altKey || event.metaKey || 
+    var modifier = event.ctrlKey || event.altKey ||
+                  (event.metaKey && event.keyCode !== key.down && event.keyCode !== key.up) ||
                   (event.shiftKey && event.keyCode !== key.spacebar);
 
     // our own tracked active element could've been removed from the DOM
@@ -429,11 +430,25 @@ function keydown(event) {
 
     switch (event.keyCode) {
         case key.up:
-            y = -options.arrowScroll;
+            if (!event.metaKey) {
+                y = -options.arrowScroll;
+                break;
+            }
+            // Fall through to treat cmd+up as home
+        case key.home:
+            y = -overflowing.scrollTop;
             break;
         case key.down:
-            y = options.arrowScroll;
-            break;         
+            if (!event.metaKey) {
+                y = options.arrowScroll;
+                break;
+            }
+            // Fall through to treat cmd+down as end
+        case key.end:
+            var scroll = overflowing.scrollHeight - overflowing.scrollTop;
+            var scrollRemaining = scroll - clientHeight;
+            y = (scrollRemaining > 0) ? scrollRemaining+10 : 0;
+            break;
         case key.spacebar: // (+ shift)
             shift = event.shiftKey ? 1 : -1;
             y = -shift * clientHeight * 0.9;
@@ -443,14 +458,6 @@ function keydown(event) {
             break;
         case key.pagedown:
             y = clientHeight * 0.9;
-            break;
-        case key.home:
-            y = -overflowing.scrollTop;
-            break;
-        case key.end:
-            var scroll = overflowing.scrollHeight - overflowing.scrollTop;
-            var scrollRemaining = scroll - clientHeight;
-            y = (scrollRemaining > 0) ? scrollRemaining+10 : 0;
             break;
         case key.left:
             x = -options.arrowScroll;


### PR DESCRIPTION
They work like Home and End. In particular, handling them lets us
take advantage of fixes in this extension that address various bugs
in Chrome with scrolling not working.