### PR TITLE
fix horizontal scrolling on linux

### DIFF
--- a/src/sscr.js
+++ b/src/sscr.js
@@ -620,8 +620,8 @@ function postScrollToParent(deltaX, deltaY) {
  * HELPERS
  ***********************************************/
 
-function addEvent(type, fn) {
-    window.addEventListener(type, fn, false);
+function addEvent(type, fn, opts=false) {
+    window.addEventListener(type, fn, opts);
 }
 
 function removeEvent(type, fn) {
@@ -734,7 +734,7 @@ function pulse(x) {
 // new standard wheel event from Chrome 31+
 var wheelEvent = 'onwheel' in document.createElement('div') ? 'wheel' : 'mousewheel'; 
 
-addEvent(wheelEvent, wheel);
+addEvent(wheelEvent, wheel, {passive: true});
 addEvent('mousedown', mousedown);
 addEvent('keydown', keydown);
 addEvent('load', loaded);


### PR DESCRIPTION
Noticed this in console (verbose mode on):
```
sscr.js:624 [Violation] Added non-passive event listener to a scroll-blocking 'wheel' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952
addEvent @ sscr.js:624
(anonymous) @ sscr.js:737
```

Fixes #175 