### PR TITLE
Fixed zero values loaded from storage not being set in the form.

### DIFF
--- a/pages/options.js
+++ b/pages/options.js
@@ -80,7 +80,7 @@ function initWithOptions(optionsSynced) {
     for (var key in options) {
       if (isCheckbox(key)) {
           byId(key).checked = options[key];
-      } else if (options[key]) {
+      } else if (options[key] !== undefined) {
           byId(key).value = options[key];
       }
     }


### PR DESCRIPTION
Fixed zero values loaded from storage not being set in the form.
If you disable acceleration (by setting it to 0), you will not be able to update changes without needing to put it to zero again each time. This PR fixes that.