### PR TITLE
Prevent hijacking keyboard input on web components.

### DIFF
--- a/src/sscr.js
+++ b/src/sscr.js
@@ -420,8 +420,10 @@ function keydown(event) {
     // or inside interactive elements
     var inputNodeNames = /^(textarea|select|embed|object)$/i;
     var buttonTypes = /^(button|submit|radio|checkbox|file|color|image)$/i;
+    var webComponents = /-/i;
     if ( event.defaultPrevented ||
          inputNodeNames.test(target.nodeName) ||
+         webComponents.test(target.nodeName) ||
          isNodeName(target, 'input') && !buttonTypes.test(target.type) ||
          isNodeName(activeElement, 'video') ||
          isInsideYoutubeVideo(event) ||


### PR DESCRIPTION
Resolves https://github.com/gblazex/smoothscroll/issues/192

To test, try the URLs on #192.

I don't see any adverse behavior with this change. SmoothScroll continues to work normally in all other situations.